### PR TITLE
Add `required` to Authorization

### DIFF
--- a/open-api/verifier.yaml
+++ b/open-api/verifier.yaml
@@ -122,7 +122,7 @@ paths:
       - name: Authorization
         in: header
         description: 'api authentication. format: ''Bearer <api_token>'''
-        required: false
+        required: true
         style: simple
         explode: false
         schema:
@@ -166,7 +166,7 @@ paths:
       - name: Authorization
         in: header
         description: 'api authentication. format: ''Bearer <api_token>'''
-        required: false
+        required: true
         style: simple
         explode: false
         schema:


### PR DESCRIPTION
Closes: https://github.com/admin-ch/CovidCertificate-App-Verifier-Service/issues/38

This PR changes the `required` property of all `Authorization` headers to `true` to reflect the need of a Bearer-Token in all requests.